### PR TITLE
Update FilterPosFromVCF.py

### DIFF
--- a/scripts/FilterPosFromVCF.py
+++ b/scripts/FilterPosFromVCF.py
@@ -38,14 +38,14 @@ def load_data(x):
 
 exclude=d(lambda:d(str))
 
-if options.indel!="None":
+if options.indel is not None:
     for l in load_data(options.indel):
         if len(l.split())<2:
                continue
         C,P=l.split()
         exclude[C][int(P)]
 
-if options.te!="None":
+if options.te is not None:
     for l in load_data(options.te):
         if l.startswith("#"):
             continue

--- a/scripts/FilterPosFromVCF.py
+++ b/scripts/FilterPosFromVCF.py
@@ -38,14 +38,14 @@ def load_data(x):
 
 exclude=d(lambda:d(str))
 
-if options.indel!="NA":
+if options.indel!="None":
     for l in load_data(options.indel):
         if len(l.split())<2:
                continue
         C,P=l.split()
         exclude[C][int(P)]
 
-if options.te!="NA":
+if options.te!="None":
     for l in load_data(options.te):
         if l.startswith("#"):
             continue


### PR DESCRIPTION
The original lines 41 and 48 will lead to an error if no indel or te option is specified. The cause is that when the option is not specified, the value assigned to options.'dest' (here they are named 'options.te' & 'options.indel') is 'None', instead of 'NA'.